### PR TITLE
fill up on start up

### DIFF
--- a/MedianFilter.h
+++ b/MedianFilter.h
@@ -19,18 +19,13 @@ public:
   {
     m_buf[m_idx] = s;
     m_idx = (m_idx + 1) % S;
-    m_cnt += (m_cnt < S) ? 1 : 0;
+
     if(m_cnt == S){
-        p_calcMedian();
+      p_calcMedian();
+    } else {
+      m_cnt++;
+      addSample(s);
     }
-  }
-  
-  /* isReady(): returns true if at least the required number of samples
-   * have been gathered, false otherwise
-   */
-  bool isReady()
-  {
-    return m_cnt == S;
   }
   
   /* getMedian(): returns the median computed when the last sample was

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ These correspond to the two template parameters. For example to create a window 
 To use your shiny new `MedianFilter` object, you will employ three simple methods:
 
 - `void addSample(s)`: Adds the sample `s` to the window.
-- `bool isReady()`: Returns `true` if we have read the necessary number of samples to compute the median.
-- `T getMedian()`: Returns the median of the window. It will have been pre-computed on the last call to `addSample`, so it costs nothing to call this several times. Note that nothing useful will be returned if we haven't read enough data, so you should check `isReady()` first.
+- `T getMedian()`: Returns the median of the window. It will have been pre-computed on the last call to `addSample`, so it costs nothing to call this several times.
 
 Sample code is provided in `examples/test/test.cpp`. The sample program obtains 1000 random integers and prints out the median after each reading. Simply compile with `g++ test.cpp`.
 

--- a/examples/MedianFilter/MedianFilter.ino
+++ b/examples/MedianFilter/MedianFilter.ino
@@ -9,9 +9,7 @@ void setup() {
         int s = rand() % 100;
         filter.addSample(s);
 
-        if (filter.isReady()) {
-            Serial.println(filter.getMedian());
-        }
+        Serial.println(filter.getMedian());
     }
 }
 

--- a/examples/test/test.cpp
+++ b/examples/test/test.cpp
@@ -11,9 +11,8 @@ int main(int argc, char **argv)
     for(int i = 0; i < 1000; i++){
         int s = rand() % 100;
         f.addSample(s);
-        if(f.isReady()){
-            std::cout << f.getMedian() << std::endl;
-        }
+
+        std::cout << f.getMedian() << std::endl;
     }
     
     return 0;

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,4 +1,3 @@
 MedianFilter   KEYWORD1
 addSample KEYWORD2
-isReady KEYWORD2
 getMedian KEYWORD2


### PR DESCRIPTION
Instead of waiting for all samples to fill up, use the first one for all. Filtering would start straight away instead of waiting a checking if it's ready.